### PR TITLE
Fixed group name parameter length to match the length of database field

### DIFF
--- a/yafsrc/YetAnotherForum.NET/install/mssql/procedures.sql
+++ b/yafsrc/YetAnotherForum.NET/install/mssql/procedures.sql
@@ -3546,7 +3546,7 @@ GO
 CREATE procedure [{databaseOwner}].[{objectQualifier}group_save](
     @GroupID		int,
     @BoardID		int,
-    @Name			nvarchar(50),
+    @Name			nvarchar(255),
     @IsAdmin		bit,
     @IsGuest		bit,
     @IsStart		bit,
@@ -8555,7 +8555,7 @@ BEGIN
 END
 GO
 
-create procedure [{databaseOwner}].[{objectQualifier}user_setrole](@BoardID int,@ProviderUserKey nvarchar(64),@Role nvarchar(50)) as
+create procedure [{databaseOwner}].[{objectQualifier}user_setrole](@BoardID int,@ProviderUserKey nvarchar(64),@Role nvarchar(255)) as
 begin
     
     declare @UserID int, @GroupID int


### PR DESCRIPTION
This allows to create groups with names up to 255 characters long
Before the fix they were trimmed at 50 chars
