### PR TITLE
Added Canonical Meta Tag Module

### DIFF
--- a/yafsrc/YetAnotherForum.NET/Modules/CanonicalMetaTagModule.cs
+++ b/yafsrc/YetAnotherForum.NET/Modules/CanonicalMetaTagModule.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Web.UI;
+using System.Web.UI.HtmlControls;
+using YAF.Types;
+using YAF.Types.Attributes;
+using YAF.Types.Constants;
+using YAF.Utils;
+using YAF.Utils.Helpers;
+
+namespace YAF.Modules
+{
+    /// <summary>
+    ///     Generates a canonical meta tag to fight the dreaded duplicate content SEO warning
+    /// </summary>
+    [YafModule("Canonical Meta Tag Module", "BonzoFestoon", 1)]
+    public class CanonicalMetaTagModule : SimpleBaseForumModule
+    {
+        public override void InitAfterPage()
+        {
+            CurrentForumPage.PreRender += CurrentForumPage_PreRender;
+        }
+
+        /// <summary>
+        ///     Handles the PreRender event of the ForumPage control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
+        private void CurrentForumPage_PreRender([NotNull] object sender, [NotNull] EventArgs e)
+        {
+            const string topicLinkParams = "t={0}";
+            var head = ForumControl.Page.Header
+                       ?? CurrentForumPage.FindControlRecursiveBothAs<HtmlHead>("YafHead");
+
+            if (head == null) return;
+            // in cases where we are not going to index, but follow, we will not add a canonical tag.
+            string tag;
+            if (ForumPageType == ForumPages.posts)
+            {
+                var topicId = PageContext.PageTopicID;
+                var topicUrl = YafBuildLink.GetLink(ForumPages.posts, true, topicLinkParams, topicId);
+                tag = $"<link rel=\"canonical\" href=\"{topicUrl}\" />";
+            }
+            else
+            {
+                // there is not much SEO value to having lists indexed 
+                // because they change as soon as some adds a new topic 
+                // or post so don't index them, but follow the links
+                tag = "<meta name=\"robots\" content=\"noindex,follow\" />";
+            }
+            if (!string.IsNullOrWhiteSpace(tag))
+                head.Controls.Add(new LiteralControl(tag));
+        }
+    }
+}

--- a/yafsrc/YetAnotherForum.NET/YAF.csproj
+++ b/yafsrc/YetAnotherForum.NET/YAF.csproj
@@ -358,6 +358,7 @@
     <Compile Include="Modules\BBCode\HideReplyThanksModule.cs" />
     <Compile Include="Modules\BBCode\SpoilerBBCodeModule.cs" />
     <Compile Include="Modules\BBCode\UserLinkBBCodeModule.cs" />
+    <Compile Include="Modules\CanonicalMetaTagModule.cs" />
     <Compile Include="Modules\Events\ClearCacheOnEvents.cs" />
     <Compile Include="Modules\Events\LastVisitEventHandler.cs" />
     <Compile Include="Modules\LanguageDirectionModule.cs" />


### PR DESCRIPTION
This helps mitigate duplicate content issues in SEO.

The Three Biggest Issues with Duplicate Content

* Search engines don't know which version(s) to include/exclude from their indices
* Search engines don't know whether to direct the link metrics (trust, authority, anchor text, link juice, etc.) to one page, or keep it separated between multiple versions
* Search engines don't know which version(s) to rank for query results

https://moz.com/learn/seo/duplicate-content 