### PR TITLE
Remove non-breaking spaces from Thanks List

### DIFF
--- a/yafsrc/YetAnotherForum.NET/controls/DisplayPost.ascx.cs
+++ b/yafsrc/YetAnotherForum.NET/controls/DisplayPost.ascx.cs
@@ -138,7 +138,7 @@ namespace YAF.Controls
 
                 if (sb.Length > 0)
                 {
-                    sb.Append(",&nbsp;");
+                    sb.Append(", ");
                 }
 
                 // Get the username related to this User ID


### PR DESCRIPTION
When there is a lot of "thanks" to a post, the list can expand the column width, because of non-breaking spaces.

This change replace the non-breaking space with a simple space, which results in thanks list to wrap when necessary instead of expanding the column width.

See this (fixed) example topic : <https://www.pathfinder-fr.org/Forum/posts/m595493-Le-combat-a-allonge>