### PR TITLE
Fixed: ModeratedPostCount can't be saved

### DIFF
--- a/yafsrc/YetAnotherForum.NET/Pages/Admin/EditForum.ascx.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/Admin/EditForum.ascx.cs
@@ -526,7 +526,7 @@ namespace YAF.Pages.Admin
 
             int? moderatedPostCount = null;
 
-            if (this.ModerateAllPosts.Checked)
+            if (!this.ModerateAllPosts.Checked)
             {
                 moderatedPostCount = this.ModeratedPostCount.Text.ToType<int>();
             }


### PR DESCRIPTION
When we uncheck the checkbox Moderate all Posts and enter a value for the textbox ModeratedPostCount, the value can't be saved