### PR TITLE
Fix possible Regex replacement error

### DIFF
--- a/yafsrc/YAF.Core/BBCode/BBCode.cs
+++ b/yafsrc/YAF.Core/BBCode/BBCode.cs
@@ -680,7 +680,7 @@ namespace YAF.Core.BBCode
                         new Regex(
                             @"(?<before>^|[ ]|\[[A-Za-z0-9]\]|\[\*\]|[A-Za-z0-9])(?<!href="")(?<!src="")(?<inner>(http://|https://)(www.)?youtube\.com\/watch\?v=(?<videoId>[A-Za-z0-9._%-]*)(\&\S+)?)",
                             RegexOptions.Multiline | RegexOptions.Compiled),
-                        "${before}<div data-oembed-url=\"//youtube.com/embed/${id}\" class=\"ratio ratio-16x9\"><iframe src=\"//youtube.com/embed/${videoId}?hd=1\"></iframe></div>",
+                        "${before}<div data-oembed-url=\"//youtube.com/embed/${videoId}\" class=\"ratio ratio-16x9\"><iframe src=\"//youtube.com/embed/${videoId}?hd=1\"></iframe></div>",
                         new[]
                         {
                             "before", "videoId"
@@ -695,7 +695,7 @@ namespace YAF.Core.BBCode
                         new Regex(
                             @"(?<before>^|[ ]|\[[A-Za-z0-9]\]|\[\*\]|[A-Za-z0-9])(?<!href="")(?<!src="")(?<inner>(http://|https://)youtu\.be\/(?<videoId>[A-Za-z0-9._%-]*)(\&\S+)?)",
                             RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled),
-                        "${before}<div data-oembed-url=\"//youtube.com/embed/${id}\" class=\"ratio ratio-16x9\"><iframe src=\"//youtube.com/embed/${videoId}?hd=1\"></iframe></div>",
+                        "${before}<div data-oembed-url=\"//youtube.com/embed/${videoId}\" class=\"ratio ratio-16x9\"><iframe src=\"//youtube.com/embed/${videoId}?hd=1\"></iframe></div>",
                         new[]
                         {
                             "before", "videoId"


### PR DESCRIPTION
While inspecting the Regex that makes up the BBCode parser, I noticed `${id}` wasn't getting replaced when I tested it on http://regexstorm.net/tester/ . It seems likely to me that it was supposed to be another instance of `${videoId}`