### PR TITLE
Update Core/Helpers/IPHelper IPv4/IPv6 handling

### DIFF
--- a/yafsrc/YAF.Core/Services/IpInfoService.cs
+++ b/yafsrc/YAF.Core/Services/IpInfoService.cs
@@ -145,7 +145,7 @@ namespace YAF.Core.Services
             try
             {
                 var url = $"{this.Get<BoardSettings>().IPLocatorUrlPath}&format=json";
-                var path = string.Format(url, IPHelper.GetIp4Address(ip));
+                var path = string.Format(url, IPHelper.GetIpAddressAsString(ip));
 
                 var webRequest = (HttpWebRequest)WebRequest.Create(path);
                 var response = (HttpWebResponse)webRequest.GetResponse();

--- a/yafsrc/YetAnotherForum.NET/Controls/DisplayPost.ascx.cs
+++ b/yafsrc/YetAnotherForum.NET/Controls/DisplayPost.ascx.cs
@@ -530,7 +530,7 @@ namespace YAF.Controls
             // We should show IP
             this.IPInfo.Visible = true;
             this.IPHolder.Visible = true;
-            var ip = IPHelper.GetIp4Address(this.PostData.DataRow.IP);
+            var ip = IPHelper.GetIpAddressAsString(this.PostData.DataRow.IP);
             this.IPLink1.HRef = string.Format(this.PageContext.BoardSettings.IPInfoPageURL, ip);
             this.IPLink1.Title = this.GetText("COMMON", "TT_IPDETAILS");
             this.IPLink1.InnerText = this.HtmlEncode(ip);

--- a/yafsrc/YetAnotherForum.NET/Pages/ActiveUsers.ascx
+++ b/yafsrc/YetAnotherForum.NET/Pages/ActiveUsers.ascx
@@ -95,9 +95,9 @@
                             <%#(Container.DataItem as ActiveUser).Platform %>
                         </td>
                         <td id="Iptd1" runat="server" visible="<%# this.PageContext.IsAdmin %>">
-                             <a id="Iplink1" href="<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL,IPHelper.GetIp4Address((Container.DataItem as ActiveUser).IP)) %>"
+                             <a id="Iplink1" href="<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL,IPHelper.GetIpAddressAsString((Container.DataItem as ActiveUser).IP)) %>"
                                 title='<%# this.GetText("COMMON","TT_IPDETAILS") %>' target="_blank" runat="server">
-                             <%# IPHelper.GetIp4Address((Container.DataItem as ActiveUser).IP)%></a>
+                             <%# IPHelper.GetIpAddressAsString((Container.DataItem as ActiveUser).IP)%></a>
                         </td>
                     </tr>
                         </ItemTemplate>

--- a/yafsrc/YetAnotherForum.NET/Pages/Admin/Admin.ascx
+++ b/yafsrc/YetAnotherForum.NET/Pages/Admin/Admin.ascx
@@ -265,9 +265,9 @@
                                     <YAF:LocalizedLabel ID="LocalizedLabel3" runat="server"
                                                         LocalizedTag="ADMIN_IPADRESS" LocalizedPage="ADMIN_ADMIN" />
                                 </span>
-                                <a id="A1" href="<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL, IPHelper.GetIp4Address((Container.DataItem as ActiveUser).IP)) %>"
+                                <a id="A1" href="<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL, IPHelper.GetIpAddressAsString((Container.DataItem as ActiveUser).IP)) %>"
                                    title='<%# this.GetText("COMMON","TT_IPDETAILS") %>' target="_blank" runat="server">
-                                    <%# IPHelper.GetIp4Address((Container.DataItem as ActiveUser).IP)%></a>
+                                    <%# IPHelper.GetIpAddressAsString((Container.DataItem as ActiveUser).IP)%></a>
                             </div>
                             <div>
                                 <span class="fw-bold">

--- a/yafsrc/YetAnotherForum.NET/Pages/Admin/BannedIps.ascx
+++ b/yafsrc/YetAnotherForum.NET/Pages/Admin/BannedIps.ascx
@@ -77,10 +77,10 @@
                     <asp:HiddenField ID="fID" Value='<%# this.Eval("ID") %>' runat="server"/>
                     <h5 class="mb-1 text-break">
                         <asp:HyperLink runat="server" ID="Mask"
-                                       Href='<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL, IPHelper.GetIp4Address(this.Eval("Mask").ToString())) %>'
+                                       Href='<%# string.Format(this.PageContext.BoardSettings.IPInfoPageURL, IPHelper.GetIpAddressAsString(this.Eval("Mask").ToString())) %>'
                                        ToolTip='<%#this.GetText("COMMON", "TT_IPDETAILS") %>'
                                        Target="_blank">
-                            <%# this.HtmlEncode(IPHelper.GetIp4Address(this.Eval("Mask").ToString())) %>
+                            <%# this.HtmlEncode(IPHelper.GetIpAddressAsString(this.Eval("Mask").ToString())) %>
                         </asp:HyperLink>
                     </h5>
                     <small class="d-none d-md-block">

--- a/yafsrc/YetAnotherForum.NET/Pages/MessageHistory.ascx.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/MessageHistory.ascx.cs
@@ -228,9 +228,9 @@ namespace YAF.Pages
         /// </returns>
         protected string GetIpAddress(MessageHistoryTopic dataItem)
         {
-            var ip = IPHelper.GetIp4Address(dataItem.IP);
+            var ip = IPHelper.GetIpAddressAsString(dataItem.IP);
 
-            return ip.IsSet() ? ip : IPHelper.GetIp4Address(dataItem.MessageIP);
+            return ip.IsSet() ? ip : IPHelper.GetIpAddressAsString(dataItem.MessageIP);
         }
 
         /// <summary>


### PR DESCRIPTION
Current IPHelper.GetIp4Address behavior fails for most usages because IPv6 does not backwards map to IPv4 address space.  Only under certain conditions which are rare at this point.

Dual-Stack hosts have issues where IPv6 is not shown or used - and current code defaults to the "server/host IPv4" as the response when no IPv4 is found.  Unsure how this can affect server's own IP in the ban feature - but appears it could be an issue as ANY user where the IPv6 doesn't return an IPv4 address and the result defaults to same server IP.

New behavior adds function GetIpAddressAsString(string InputAddress), and found references to GetIp4Address updated accordingly.  Additionally internal behavior now tries original method of gaining IPv4 from IPv6 via rDNS - when this fails, returns an IPv6 if supplied IPv6 is verified, or returns 127.0.0.1 (localhost - which should NEVER happen) as last resort.  

Testing of BannedIP feature is needed to make sure  submitted changes do not cause issue in that module/service.