### PR TITLE
Some relative time string does not display correctly in French

### DIFF
--- a/yafsrc/YetAnotherForum.NET/languages/french.json
+++ b/yafsrc/YetAnotherForum.NET/languages/french.json
@@ -14672,7 +14672,7 @@
           },
           {
             "@tag": "PAST",
-            "#text": "il y a {0} ans"
+            "#text": "il y a {0}"
           },
           {
             "@tag": "S",


### PR DESCRIPTION
 Here is an update of "PAST" entry in "french.json". 
An hardcoded "ans" was always here at the end of the formatted string.

> Example : 3 days ago => Il y a 3 jours 

