### PR TITLE
Update bootstrap-touchspin.js so border-radius is applied

### DIFF
--- a/yafsrc/YetAnotherForum.NET/wwwroot/lib/forum/bootstrap-touchspin.js
+++ b/yafsrc/YetAnotherForum.NET/wwwroot/lib/forum/bootstrap-touchspin.js
@@ -33,7 +33,7 @@
 
         plusButton.innerHTML = '<i class="fa-solid fa-plus"></i>';
 
-        input.parentNode.insertBefore(plusButton, input.nextSibling);
+        input.parentNode.append(plusButton);
     });
 
     function touchSpinDown() {


### PR DESCRIPTION
currently the last element is a hidden input
`<input name="__Invariant" type="hidden" value="Input.DaysOld">` which makes the border-radius fail to apply to the button. By appending the button instead of inserting it, the + button becomes the last element of the parent