### PR TITLE
Minor changes to albums

### DIFF
--- a/yafsrc/YetAnotherForum.NET/Pages/Album.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/Album.cshtml.cs
@@ -160,10 +160,10 @@ public class AlbumModel : ForumPage
             this.PageBoardContext.PageIndex,
             this.PageBoardContext.BoardSettings.AlbumImagesPerPage);
 
-        if (albumImageList.NullOrEmpty())
-        {
-            return this.Get<LinkBuilder>().RedirectInfoPage(InfoMessage.Invalid);
-        }
+        //if (albumImageList.NullOrEmpty())
+        //{
+        //    return this.Get<LinkBuilder>().RedirectInfoPage(InfoMessage.Invalid);
+        //}
 
         this.Images = albumImageList;
 

--- a/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
@@ -332,7 +332,7 @@ public class EditAlbumImagesModel : ForumPageRegistered
 
             // remove the "period"
             extension = extension.Replace(".", string.Empty);
-            string[] imageExtensions = ["jpg", "gif", "png", "bmp"];
+            string[] imageExtensions = ["jpg", "jpeg", "gif", "png", "bmp"];
 
             // If we don't get a match from the db, then the extension is not allowed
             // also, check to see an image is being uploaded.

--- a/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
@@ -256,7 +256,14 @@ public class EditAlbumImagesModel : ForumPageRegistered
         {
             this.AlbumId = albumId;
 
-            this.AlbumTitle = this.GetRepository<UserAlbum>().GetTitle(this.AlbumId.Value);
+            try
+            {
+                this.AlbumTitle = this.GetRepository<UserAlbum>().GetTitle(this.AlbumId.Value);
+            }
+            catch {
+                return this.Get<LinkBuilder>().RedirectInfoPage(InfoMessage.Invalid);
+            }
+
 
             this.Images = this.GetRepository<UserAlbumImage>().List(this.AlbumId.Value);
 

--- a/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/EditAlbumImages.cshtml.cs
@@ -261,10 +261,10 @@ public class EditAlbumImagesModel : ForumPageRegistered
             this.Images = this.GetRepository<UserAlbumImage>().List(this.AlbumId.Value);
 
             // Check if user album is empty
-            if (this.Images.NullOrEmpty())
-            {
-                return this.DeleteAlbum(this.AlbumId.Value);
-            }
+            //if (this.Images.NullOrEmpty())
+            //{
+            //    return this.DeleteAlbum(this.AlbumId.Value);
+            //}
         }
 
         // Has the user uploaded maximum number of images?

--- a/yafsrc/YetAnotherForum.NET/wwwroot/languages/english.json
+++ b/yafsrc/YetAnotherForum.NET/wwwroot/languages/english.json
@@ -9614,7 +9614,7 @@
           },
           {
             "@tag": "SELECT_FILE",
-            "#text": "Select an Image File ('.jpg', '.gif', '.png' or '.bmp') you want to upload."
+            "#text": "Select an Image File ('.jpg', '.jpeg', '.gif', '.png' or '.bmp') you want to upload."
           },
           {
             "@tag": "TITLE",


### PR DESCRIPTION
Changed albums so they can handle an empty album.  Fixes the error when creating an album, uploading an image that's two large, clicking to go back then threw an error because the album had been deleted.  Now it returns back to the album, allowing the user to upload another image.  Also added try/catch block when retrieving the album title.