### PR TITLE
Return EmptyResult instead of null from LinkBuilder.Redirect fallback

### DIFF
--- a/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
+++ b/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
@@ -354,7 +354,7 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
 
         this.Get<IHttpContextAccessor>().HttpContext?.Response.Redirect(page.GetPageName());
 
-        return null;
+        return new EmptyResult();
     }
 
     /// <summary>


### PR DESCRIPTION
When neither CurrentForumPage nor CurrentForumController is set (e.g. Install page redirecting away after forum is already installed), the fallback path returns null as IActionResult after calling Response.Redirect(), causing a NullReferenceException.