### PR TITLE
Encode topic name in GeneratePageTitle in ForumPageExtensions

### DIFF
--- a/yafsrc/YAFNET.Web/Extensions/ForumPageExtension.cs
+++ b/yafsrc/YAFNET.Web/Extensions/ForumPageExtension.cs
@@ -59,8 +59,8 @@ public static class ForumPageExtensions
                     {
                         // Tack on the topic we're viewing
                         title.Append(
-                            BoardContext.Current.Get<IBadWordReplace>().Replace(
-                                BoardContext.Current.PageTopic.TopicName.Truncate(80)));
+                            page.HtmlEncode(BoardContext.Current.Get<IBadWordReplace>().Replace(
+                                BoardContext.Current.PageTopic.TopicName.Truncate(80))));
                     }
 
                     break;
@@ -69,8 +69,8 @@ public static class ForumPageExtensions
                     {
                         // Tack on the topic we're viewing
                         title.Append(
-                            BoardContext.Current.Get<IBadWordReplace>().Replace(
-                                BoardContext.Current.PageTopic.TopicName.Truncate(80)));
+                            page.HtmlEncode(BoardContext.Current.Get<IBadWordReplace>().Replace(
+                                BoardContext.Current.PageTopic.TopicName.Truncate(80))));
                     }
 
                     // Append Current Page


### PR DESCRIPTION
Match the encoding used in Post.cshtml.cs where TopicName is passed through HtmlEncode before display. Also match the other branches in GeneratePageTitle() itself.