### PR TITLE
Fix double slash in sitemap URLs

### DIFF
--- a/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/SiteMap.cshtml.cs
+++ b/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/SiteMap.cshtml.cs
@@ -68,7 +68,7 @@ public class SiteMapModel : ForumPage
             forum => siteMap.Add(
                 new UrlLocation {
                                     Url =
-                                        $"{this.Request.BaseUrl()}{BoardContext.Current.Get<ILinkBuilder>().GetForumLink(
+                                        $"{this.Request.BaseUrl().TrimEnd('/')}{BoardContext.Current.Get<ILinkBuilder>().GetForumLink(
                                             forum.Item1.ID,
                                             forum.Item1.Name)}",
                                     Priority = 0.8D,

--- a/yafsrc/YetAnotherForum.NET/Pages/SiteMap.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/SiteMap.cshtml.cs
@@ -68,7 +68,7 @@ public class SiteMapModel : ForumPage
             forum => siteMap.Add(
                 new UrlLocation {
                                     Url =
-                                        $"{this.Request.BaseUrl()}{BoardContext.Current.Get<ILinkBuilder>().GetForumLink(
+                                        $"{this.Request.BaseUrl().TrimEnd('/')}{BoardContext.Current.Get<ILinkBuilder>().GetForumLink(
                                             forum.Item1.ID,
                                             forum.Item1.Name)}",
                                     Priority = 0.8D,


### PR DESCRIPTION
BaseUrl() returns a trailing slash and GetForumLink() returns a leading slash, producing a double // in generated sitemap URLs.