### PR TITLE
Return 404 for unrecognized handler names that fall through to Index

### DIFF
--- a/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/Index.cshtml.cs
+++ b/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/Index.cshtml.cs
@@ -83,6 +83,13 @@ public class IndexModel : ForumPage
     /// </summary>
     public async Task<IActionResult> OnGetAsync()
     {
+        // Return 404 for unrecognized handler names that fall through to OnGetAsync
+        // (e.g. /asdf would otherwise render the index page)
+        if (this.RouteData.Values.TryGetValue("handler", out var handler) && handler is not null)
+        {
+            return this.NotFound();
+        }
+
         await this.BindDataAsync();
 
         return this.Page();

--- a/yafsrc/YetAnotherForum.NET/Pages/Index.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/Index.cshtml.cs
@@ -83,6 +83,13 @@ public class IndexModel : ForumPage
     /// </summary>
     public async Task<IActionResult> OnGetAsync()
     {
+        // Return 404 for unrecognized handler names that fall through to OnGetAsync
+        // (e.g. /asdf would otherwise render the index page)
+        if (this.RouteData.Values.TryGetValue("handler", out var handler) && handler is not null)
+        {
+            return this.NotFound();
+        }
+
         await this.BindDataAsync();
 
         return this.Page();


### PR DESCRIPTION
Improves search engine optimization by reducing "duplicate content" pages