### PR TITLE
Update ampersand URL handling to ensure "A & B" becomes "A-and-B"

### DIFF
--- a/yafsrc/YAFNET.Core/Helpers/UrlRewriteHelper.cs
+++ b/yafsrc/YAFNET.Core/Helpers/UrlRewriteHelper.cs
@@ -47,7 +47,7 @@ public static class UrlRewriteHelper
         var sb = new StringBuilder();
 
         // fix ampersand...
-        inputString = inputString.Replace(" & ", "and").Replace("ـ", string.Empty);
+        inputString = inputString.Replace(" & ", " and ").Replace("ـ", string.Empty);
 
         // trim...
         inputString = Config.UrlRewritingMode == "Unicode"

--- a/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
+++ b/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
@@ -24,12 +24,9 @@
 
 namespace YAF.Core.Services;
 
-using System.Web;
-
 using Microsoft.AspNetCore.Routing;
-
-using YAF.Types.Objects;
 using YAF.Types.Models;
+using YAF.Types.Objects;
 
 /// <summary>
 /// Class with link building functions.
@@ -170,7 +167,7 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
     /// </returns>
     public string GetTopicLink(int topicId, string topicName)
     {
-        var topicSubject = HttpUtility.HtmlEncode(this.Get<IBadWordReplace>().Replace(topicName));
+        var topicSubject = this.Get<IBadWordReplace>().Replace(topicName);
 
         return this.Get<ILinkBuilder>().GetLink(
             ForumPages.Posts,
@@ -191,7 +188,7 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
     /// </returns>
     public string GetMessageLink(Topic topic, int messageId)
     {
-        var topicSubject = HttpUtility.HtmlEncode(this.Get<IBadWordReplace>().Replace(topic.TopicName));
+        var topicSubject = this.Get<IBadWordReplace>().Replace(topic.TopicName);
 
         return this.Get<ILinkBuilder>().GetLink(
             ForumPages.Post,
@@ -212,7 +209,7 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
     /// </returns>
     public string GetMessageLink(string topicName, int messageId)
     {
-        var topicSubject = HttpUtility.HtmlEncode(this.Get<IBadWordReplace>().Replace(topicName));
+        var topicSubject = this.Get<IBadWordReplace>().Replace(topicName);
 
         return this.Get<ILinkBuilder>().GetLink(
             ForumPages.Post,


### PR DESCRIPTION
Previously, in a forum name, "A & B" would become "AandB". The update to UrlRewriteHelper.CleanStringForUrl() addresses that.

Previously, in a topic name, "A & B" would become "A--amp--B" because the topic name was being double-encoded, first in LinkBuilder.GetTopicLink/GetMessageLink functions (to "A &amp; B"), and then again by UrlRewriteHelper.CleanStringForUrl() when called from LinkBuilder.GetLink(). Removing the first encoding is safe because all paths still call CleanStringForUrl().

Note: "A&B" becomes "A-B", same as before this change.