### PR TITLE
Add category URL segments (/Category/{id}/{name})

### DIFF
--- a/yafsrc/YAFNET.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/yafsrc/YAFNET.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -26,6 +26,7 @@ using Autofac.Extensions.DependencyInjection;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -107,6 +108,9 @@ public static class IApplicationBuilderExtensions
             app.UseMiddleware<CheckBannedIps>();
             app.UseMiddleware<CheckBannedUserAgents>();
             app.UseMiddleware<CheckBannedCountries>();
+
+            // Rewrite /Category/{id}/{name} to /Index?c={id}
+            app.UseRewriter(CategoryRouteHelper.AddCategoryRules(new RewriteOptions(), serviceLocator.Get<BoardConfiguration>().Area));
 
             app.UseRouting();
 

--- a/yafsrc/YAFNET.Core/Helpers/CategoryRouteHelper.cs
+++ b/yafsrc/YAFNET.Core/Helpers/CategoryRouteHelper.cs
@@ -1,0 +1,66 @@
+/* Yet Another Forum.NET
+ * Copyright (C) 2003-2005 Bjørnar Henden
+ * Copyright (C) 2006-2013 Jaben Cargman
+ * Copyright (C) 2014-2026 Ingo Herbote
+ * https://www.yetanotherforum.net/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+ * https://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace YAF.Core.Helpers;
+
+using Microsoft.AspNetCore.Rewrite;
+
+using YAF.Types.Extensions;
+
+/// <summary>
+/// Centralizes the /Category/{id}/{name} route definition
+/// used by both URL generation (LinkBuilder) and URL rewriting (middleware).
+/// </summary>
+public static class CategoryRouteHelper
+{
+    /// <summary>
+    /// The route segment.
+    /// </summary>
+    private const string PathSegment = "Category";
+
+    /// <summary>
+    /// Builds a category URL: /Category/{id}/{name} or /{area}/Category/{id}/{name}.
+    /// </summary>
+    public static string BuildUrl(string area, int categoryId, string categoryName)
+    {
+        var name = UrlRewriteHelper.CleanStringForUrl(categoryName);
+
+        return area.IsSet()
+            ? $"/{area}/{PathSegment}/{categoryId}/{name}"
+            : $"/{PathSegment}/{categoryId}/{name}";
+    }
+
+    /// <summary>
+    /// Adds rewrite rules that map /Category/{id}/{name} to the Index page.
+    /// </summary>
+    public static RewriteOptions AddCategoryRules(RewriteOptions options, string area)
+    {
+        var areaSegment = area.IsSet() ? $"{area}/" : string.Empty;
+
+        return options
+            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)$", $"{areaSegment}Index?c=$1", skipRemainingRules: true)
+            // Also rewrite /Category/{id}/{name}/{handler} so page handlers like ShowMore work
+            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)/([A-Za-z]+)$", $"{areaSegment}Index/$3?c=$1", skipRemainingRules: true);
+    }
+}

--- a/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
+++ b/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
@@ -137,9 +137,7 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
     /// </returns>
     public string GetCategoryLink(int categoryId, string categoryName)
     {
-        return this.Get<ILinkBuilder>().GetLink(
-            ForumPages.Index,
-            new {c = categoryId, name = categoryName});
+        return CategoryRouteHelper.BuildUrl(this.Get<BoardConfiguration>().Area, categoryId, categoryName);
     }
 
     /// <summary>


### PR DESCRIPTION
Category links previously used query strings (?c=16&name=...). Now they use /Category/{id}/{name}, similar to the v3 format (/category/{id}-{name}) but updated to match the v4 slug style used by Topics and Posts.

Uses URL rewrite middleware to map incoming /Category/{id}/{name} requests to the Index page. Route definition is centralized in CategoryRouteHelper, which provides both the URL builder (used by LinkBuilder.GetCategoryLink) and the rewrite rules.