### PR TITLE
Respect RouteOptions in category URL generation and rewriting

### DIFF
--- a/yafsrc/YAFNET.Core/Extensions/IApplicationBuilderExtensions.cs
+++ b/yafsrc/YAFNET.Core/Extensions/IApplicationBuilderExtensions.cs
@@ -27,6 +27,7 @@ using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Rewrite;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -110,7 +111,10 @@ public static class IApplicationBuilderExtensions
             app.UseMiddleware<CheckBannedCountries>();
 
             // Rewrite /Category/{id}/{name} to /Index?c={id}
-            app.UseRewriter(CategoryRouteHelper.AddCategoryRules(new RewriteOptions(), serviceLocator.Get<BoardConfiguration>().Area));
+            app.UseRewriter(CategoryRouteHelper.AddCategoryRules(
+                new RewriteOptions(),
+                serviceLocator.Get<BoardConfiguration>().Area,
+                serviceLocator.Get<IOptions<RouteOptions>>().Value));
 
             app.UseRouting();
 

--- a/yafsrc/YAFNET.Core/Helpers/CategoryRouteHelper.cs
+++ b/yafsrc/YAFNET.Core/Helpers/CategoryRouteHelper.cs
@@ -25,6 +25,7 @@
 namespace YAF.Core.Helpers;
 
 using Microsoft.AspNetCore.Rewrite;
+using Microsoft.AspNetCore.Routing;
 
 using YAF.Types.Extensions;
 
@@ -41,28 +42,65 @@ public static class CategoryRouteHelper
 
     /// <summary>
     /// Builds a category URL: /Category/{id}/{name} or /{area}/Category/{id}/{name}.
+    /// When <paramref name="routeOptions"/> is provided, the URL respects
+    /// <see cref="RouteOptions.LowercaseUrls"/> and <see cref="RouteOptions.AppendTrailingSlash"/>.
     /// </summary>
-    public static string BuildUrl(string area, int categoryId, string categoryName)
+    public static string BuildUrl(string area, int categoryId, string categoryName,
+        RouteOptions routeOptions = null)
     {
         var name = UrlRewriteHelper.CleanStringForUrl(categoryName);
 
-        return area.IsSet()
+        var url = area.IsSet()
             ? $"/{area}/{PathSegment}/{categoryId}/{name}"
             : $"/{PathSegment}/{categoryId}/{name}";
+
+        if (routeOptions != null)
+        {
+            if (routeOptions.LowercaseUrls)
+            {
+                url = url.ToLowerInvariant();
+            }
+            if (routeOptions.AppendTrailingSlash && !url.EndsWith('/'))
+            {
+                url += "/";
+            }
+        }
+
+        return url;
     }
 
     /// <summary>
     /// Adds rewrite rules that map /Category/{id}/{name} to the Index page.
+    /// When <paramref name="routeOptions"/> is provided, the rewrite targets respect
+    /// <see cref="RouteOptions.LowercaseUrls"/> and <see cref="RouteOptions.AppendTrailingSlash"/>.
     /// </summary>
-    public static RewriteOptions AddCategoryRules(RewriteOptions options, string area)
+    public static RewriteOptions AddCategoryRules(RewriteOptions options, string area,
+        RouteOptions routeOptions = null)
     {
         var areaSegment = area.IsSet() ? $"{area}/" : string.Empty;
+        var indexPage = "Index";
+
+        var trailingSlash = "";
+        if (routeOptions != null)
+        {
+            if (routeOptions.AppendTrailingSlash)
+            {
+                trailingSlash = "/";
+            }
+            if (routeOptions.LowercaseUrls)
+            {
+                areaSegment = areaSegment.ToLowerInvariant();
+                indexPage = indexPage.ToLowerInvariant();
+            }
+        }
 
         return options
-            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)$", $"{areaSegment}Index?c=$1",
+            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)/?$",
+                $"{areaSegment}{indexPage}{trailingSlash}?c=$1",
                 skipRemainingRules: true)
             // Also rewrite /Category/{id}/{name}/{handler} so page handlers like ShowMore work
-            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)/([A-Za-z]+)$", $"{areaSegment}Index/$3?c=$1",
+            .AddRewrite($@"(?i)^{areaSegment}{PathSegment}/(\d+)/([^/]+)/([A-Za-z]+)/?$",
+                $"{areaSegment}{indexPage}/$3{trailingSlash}?c=$1",
                 skipRemainingRules: true);
     }
 }

--- a/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
+++ b/yafsrc/YAFNET.Core/Services/LinkBuilder.cs
@@ -25,6 +25,7 @@
 namespace YAF.Core.Services;
 
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 
 using YAF.Types.Models;
 using YAF.Types.Objects;
@@ -135,7 +136,11 @@ public class LinkBuilder : IHaveServiceLocator, ILinkBuilder
     /// </returns>
     public string GetCategoryLink(int categoryId, string categoryName)
     {
-        return CategoryRouteHelper.BuildUrl(this.Get<BoardConfiguration>().Area, categoryId, categoryName);
+        return CategoryRouteHelper.BuildUrl(
+            this.Get<BoardConfiguration>().Area, 
+            categoryId, 
+            categoryName,
+            this.Get<IOptions<RouteOptions>>().Value);
     }
 
     /// <summary>


### PR DESCRIPTION
CategoryRouteHelper.BuildUrl and AddCategoryRules previously hardcoded PascalCase URLs with no trailing slash. Consuming apps that enforce lowercase URLs or trailing slashes via middleware would see extra redirects that exposed the internal /Index?c={id} rewrite target.

Both methods now accept an optional RouteOptions parameter to respect LowercaseUrls and AppendTrailingSlash. The rewrite regexes also accept an optional trailing slash on input for consistency with ASP.NET Core routing, which matches both forms regardless of the setting.