### PR TITLE
Fix sitemap XML: UTF-8 encoding, correct namespace, and element order

### DIFF
--- a/yafsrc/YAFNET.Types/Constants/UrlLocation.cs
+++ b/yafsrc/YAFNET.Types/Constants/UrlLocation.cs
@@ -75,25 +75,25 @@ public class UrlLocation
     /// <summary>
     /// Gets or sets the url.
     /// </summary>
-    [XmlElement("loc")]
+    [XmlElement("loc", Order = 1)]
     public string Url { get; set; }
-
-    /// <summary>
-    /// Gets or sets the change frequency.
-    /// </summary>
-    [XmlElement("changefreq")]
-    public ChangeFrequencies? ChangeFrequency { get; set; }
 
     /// <summary>
     /// Gets or sets the last modified.
     /// </summary>
-    [XmlElement("lastmod")]
+    [XmlElement("lastmod", Order = 2)]
     public string LastModified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the change frequency.
+    /// </summary>
+    [XmlElement("changefreq", Order = 3)]
+    public ChangeFrequencies? ChangeFrequency { get; set; }
 
     /// <summary>
     /// Gets or sets the priority.
     /// </summary>
-    [XmlElement("priority")]
+    [XmlElement("priority", Order = 4)]
     public double? Priority { get; set; }
 
     /// <summary>

--- a/yafsrc/YAFNET.Types/Objects/Sitemap.cs
+++ b/yafsrc/YAFNET.Types/Objects/Sitemap.cs
@@ -33,7 +33,7 @@ using YAF.Types.Extensions;
 /// <summary>
 /// The site Map. XML
 /// </summary>
-[XmlRoot("urlset", Namespace = "https://www.sitemaps.org/schemas/sitemap/0.9")]
+[XmlRoot("urlset", Namespace = "http://www.sitemaps.org/schemas/sitemap/0.9")]
 public class SiteMap
 {
     /// <summary>

--- a/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/SiteMap.cshtml.cs
+++ b/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/SiteMap.cshtml.cs
@@ -28,6 +28,8 @@ namespace YAF.Pages;
 
 using System.Globalization;
 using System.IO;
+using System.Net.Mime;
+using System.Text;
 using System.Xml.Serialization;
 
 using Core.Model;
@@ -85,13 +87,14 @@ public class SiteMapModel : ForumPage
 
         var xmlSerializer = new XmlSerializer(typeof(SiteMap));
 
-        using var textWriter = new StringWriter();
-        xmlSerializer.Serialize(textWriter, siteMap);
+        using var writer = new Utf8StringWriter();
+        xmlSerializer.Serialize(writer, siteMap);
 
-        return new ContentResult {
-                                     ContentType = "application/xml",
-                                     Content = textWriter.ToString(),
-                                     StatusCode = 200
-                                 };
+        return this.Content(writer.ToString(), MediaTypeNames.Application.Xml, Encoding.UTF8);
+    }
+
+    private sealed class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
     }
 }

--- a/yafsrc/YetAnotherForum.NET/Pages/SiteMap.cshtml.cs
+++ b/yafsrc/YetAnotherForum.NET/Pages/SiteMap.cshtml.cs
@@ -28,12 +28,14 @@ namespace YAF.Pages;
 
 using System.Globalization;
 using System.IO;
+using System.Net.Mime;
+using System.Text;
 using System.Xml.Serialization;
 
 using Core.Model;
 
-using Types.Models;
 using Types.Interfaces;
+using Types.Models;
 
 using YAF.Core.Context;
 using YAF.Types.Objects;
@@ -85,13 +87,14 @@ public class SiteMapModel : ForumPage
 
         var xmlSerializer = new XmlSerializer(typeof(SiteMap));
 
-        using var textWriter = new StringWriter();
-        xmlSerializer.Serialize(textWriter, siteMap);
+        using var writer = new Utf8StringWriter();
+        xmlSerializer.Serialize(writer, siteMap);
 
-        return new ContentResult {
-                                     ContentType = "application/xml",
-                                     Content = textWriter.ToString(),
-                                     StatusCode = 200
-                                 };
+        return this.Content(writer.ToString(), MediaTypeNames.Application.Xml, Encoding.UTF8);
+    }
+
+    private sealed class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
     }
 }


### PR DESCRIPTION
- Use XmlWriter with UTF-8 encoding instead of StringWriter (which defaults to UTF-16, rejected by Google)
- Fix urlset namespace from https to http per sitemaps.org spec
- Reorder UrlLocation properties to match XSD sequence: loc, lastmod, changefreq, priority
- Add explicit Order attributes to guarantee serialization order