### PR TITLE
Fix attachment list not loading on EditMessage page

### DIFF
--- a/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/EditMessage.cshtml
+++ b/yafsrc/YAFNET.UI/YAFNET.RazorPages/Areas/Forums/Pages/EditMessage.cshtml
@@ -182,6 +182,7 @@
 		</script>
 	}
     
+    @await Html.PartialAsync("_PostScriptsPartial")
     @await Html.PartialAsync("_BBCodeEditorScriptsPartial")
 
     @if (Model.PageBoardContext.UploadAccess)

--- a/yafsrc/YetAnotherForum.NET/Pages/EditMessage.cshtml
+++ b/yafsrc/YetAnotherForum.NET/Pages/EditMessage.cshtml
@@ -182,6 +182,7 @@
 		</script>
 	}
     
+    @await Html.PartialAsync("_PostScriptsPartial")
     @await Html.PartialAsync("_BBCodeEditorScriptsPartial")
 
     @if (Model.PageBoardContext.UploadAccess)


### PR DESCRIPTION
EditMessage.cshtml was missing _PostScriptsPartial, so post.min.js (which initializes the attachment list via getPaginationData) was never loaded. The spinner would show indefinitely with no error. Every other posting page (PostMessage, PostTopic, Posts, etc.) already included it.